### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,22 @@
 ## Installation
 ### Using `ddev get`
 To install `ddev-tightvnc`, use the following commands:
+
+For DDEV v1.23.5 or above run
+
+```bash
+ddev add-on get thursdaybw/ddev-tightvnc
+```
+
+For earlier versions of DDEV run
+
 ```bash
 ddev get thursdaybw/ddev-tightvnc
+```
+
+Then restart your project
+
+```bash
 ddev restart
 ```
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.